### PR TITLE
fix: 支持 macOS 虚拟音频设备 (BlackHole, Soundflower)

### DIFF
--- a/meeting_translator/audio_device_manager.py
+++ b/meeting_translator/audio_device_manager.py
@@ -161,7 +161,10 @@ class AudioDeviceManager:
                         '主声音捕获' in device_name,             # 中文：主声音捕获驱动程序
                         'Wave Out Mix' in device_name,         # 某些声卡的混音设备
                         'What U Hear' in device_name,          # Creative 声卡
-                        'Loopback' in device_name.lower()      # 通用 loopback 关键词
+                        'Loopback' in device_name.lower(),     # 通用 loopback 关键词
+                        'BlackHole' in device_name,            # macOS: BlackHole 虚拟音频设备
+                        'Soundflower' in device_name,          # macOS: Soundflower 虚拟音频设备
+                        'Ground Control' in device_name        # macOS: 另一个虚拟音频工具
                     ])
 
                     # 合并判断


### PR DESCRIPTION
## 问题描述

macOS 用户使用 BlackHole 或 Soundflower 进行音频捕获时，音频设备列表为空，无法选择输入设备。

### 根本原因

`audio_device_manager.py` 中的 loopback 设备检测仅支持 Windows 特定的设备名称：
- Stereo Mix
- CABLE Output  
- VoiceMeeter Output
- 等

macOS 的虚拟音频设备（如 BlackHole）不在检测列表中，导致被过滤掉。

## 解决方案

添加 macOS 虚拟音频设备名称到 loopback 设备检测列表：
- **BlackHole** (最常用的 macOS 虚拟音频设备)
- **Soundflower** (旧版常用工具)
- **Ground Control** (另一个虚拟音频工具)

## 修改内容

**文件**: `meeting_translator/audio_device_manager.py:164-167`

```python
is_legacy_loopback = any([
    # ... 现有 Windows 设备检测 ...
    'Loopback' in device_name.lower(),     # 通用 loopback 关键词
    'BlackHole' in device_name,            # macOS: BlackHole 虚拟音频设备
    'Soundflower' in device_name,          # macOS: Soundflower 虚拟音频设备
    'Ground Control' in device_name        # macOS: 另一个虚拟音频工具
])
```

## 测试

### macOS (BlackHole 安装后)
- ✅ BlackHole 设备出现在 "会议音频输入 (听模式)" 下拉菜单
- ✅ 可以正常选择并使用

### Windows
- ✅ 不影响现有 Windows loopback 设备检测
- ✅ Stereo Mix, VB-Cable 等设备仍可正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)