### PR TITLE
优化字幕窗口置顶与文本选择体验

### DIFF
--- a/meeting_translator/subtitle_window.py
+++ b/meeting_translator/subtitle_window.py
@@ -139,7 +139,7 @@ class SubtitleWindow(QWidget):
             # 重新渲染所有内容
             self._render_subtitles()
 
-            Out.debug(f"字幕已添加: {source_text} → {target_text}")
+            # Out.debug(f"字幕已添加: {source_text} → {target_text}")
         else:
             # 增量文本：临时显示在最后一行
             self.current_partial_text = target_text
@@ -195,8 +195,8 @@ class SubtitleWindow(QWidget):
                 html_parts.append(f'''
                     {source_html}
                     <p style="color: #FFFFFF; margin: 2px 0 8px 0; font-weight: bold;
-                              text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);">
-                        　　　　→ {self._escape_html(self.current_partial_text)}<span style="color: #AAAAAA; font-weight: normal;">{self._escape_html(self.current_predicted_text)}</span> <span style="color: #6496FF;">...</span>
+                              font-size: 16px; text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);">
+                        　　　　→ {self._escape_html(self.current_partial_text)}<span style="color: #AAAAAA; font-weight: normal; font-size: 16px;">{self._escape_html(self.current_predicted_text)}</span> <span style="color: #6496FF;">...</span>
                     </p>
                 ''')
             else:
@@ -204,7 +204,7 @@ class SubtitleWindow(QWidget):
                 html_parts.append(f'''
                     {source_html}
                     <p style="color: #FFFFFF; margin: 2px 0 8px 0; font-weight: bold;
-                              text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);">
+                              font-size: 16px; text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);">
                         　　　　→ {self._escape_html(self.current_partial_text)} <span style="color: #6496FF;">...</span>
                     </p>
                 ''')


### PR DESCRIPTION
背景
  - macOS 上字幕窗口偶尔失去置顶，且字幕文本无法选择复制。
  - 某些情况希望同时显示中英文，方便比对。

  修改
  - 双重置顶标志并添加 WA_MacAlwaysShowToolWindow，提升 macOS 兼容性。
  - 启用 TextBrowserInteraction，允许字幕文本选择/复制。
  - 优化双语渲染：英文/中文分行配色、阴影、字号一致；增量预测文本样式统一。

  合并建议
  - 建议使用 squash 合并，保持提交历史简洁。