### PR TITLE
fix: 避免在 macOS 上显示 WASAPI 不可用警告

### DIFF
--- a/meeting_translator/audio_device_manager.py
+++ b/meeting_translator/audio_device_manager.py
@@ -5,6 +5,7 @@
 
 import sys
 import re
+import platform
 from typing import List, Dict, Set
 
 try:
@@ -126,13 +127,14 @@ class AudioDeviceManager:
         devices = []
         device_count = self.pyaudio_instance.get_device_count()
 
-        # 获取 WASAPI host API 索引
+        # 获取 WASAPI host API 索引 (仅 Windows)
         wasapi_index = None
-        try:
-            wasapi_info = self.pyaudio_instance.get_host_api_info_by_type(pyaudio.paWASAPI)
-            wasapi_index = wasapi_info['index']
-        except Exception as e:
-            Out.warning(f"WASAPI 不可用: {e}")
+        if platform.system() == 'Windows':
+            try:
+                wasapi_info = self.pyaudio_instance.get_host_api_info_by_type(pyaudio.paWASAPI)
+                wasapi_index = wasapi_info['index']
+            except Exception as e:
+                Out.warning(f"WASAPI 不可用: {e}")
 
         for i in range(device_count):
             try:


### PR DESCRIPTION
## 修复说明

修复了在 macOS 系统上运行时出现的 `[WARNING] WASAPI 不可用: [Errno -9979] Host API not found` 警告。

## 问题原因

WASAPI (Windows Audio Session API) 是 Windows 专有的音频 API，在 macOS 上永远不可用。之前的代码没有检查操作系统就尝试获取 WASAPI 信息，导致在 macOS 上总是显示警告。

## 解决方案

- 添加了 `platform` 模块导入
- 在尝试获取 WASAPI 信息前添加操作系统检查 `platform.system() == 'Windows'`
- 只在 Windows 系统上才会尝试获取 WASAPI，从而避免在 macOS 上产生无意义的警告

## 测试

✅ 在 macOS 上不再显示 WASAPI 警告
✅ 不影响现有功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>